### PR TITLE
Add feature "to top" for regexp-based rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.1.0
+
+### Added
+
+- Parameter `$to_top` for `onUriRegexpRequested` method (it allows "override" previously declared patterns)
+
 ## v1.0.2
 
 ### Changed

--- a/src/UrlsMockHandler.php
+++ b/src/UrlsMockHandler.php
@@ -178,7 +178,7 @@ class UrlsMockHandler implements \Countable
      * @param string                                                $uri_pattern
      * @param string                                                $method
      * @param callable|Exception|PromiseInterface|ResponseInterface $response
-     * @param bool                                                  $to_top Push action into the top of stack
+     * @param bool                                                  $to_top      Push action into the top of stack
      *
      * @throws InvalidArgumentException
      *
@@ -318,8 +318,7 @@ class UrlsMockHandler implements \Countable
         array $options,
         ResponseInterface $response = null,
         $reason = null
-    )
-    {
+    ) {
         if (isset($options['on_stats']) && \is_callable($on_stats = $options['on_stats'])) {
             $on_stats(new TransferStats($request, $response, null, $reason));
         }

--- a/tests/UrlsMockHandlerTest.php
+++ b/tests/UrlsMockHandlerTest.php
@@ -127,4 +127,64 @@ class UrlsMockHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($code2, $response3->getStatusCode());
         $this->assertSame($headers2, $response3->getHeaders());
     }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testRegisterWithPassingToTopParameter()
+    {
+        $this->handler->onUriRegexpRequested('~https:\/\/goo\.gl\/.*~', $method = 'post', new Response(
+            $code1 = 200,
+            $headers1 = [],
+            $body1 = 'Content 1'
+        ));
+
+        $this->handler->onUriRegexpRequested('~https:\/\/goo\.gl\/foo.*~', $method, new Response(
+            $code2 = 202,
+            $headers2 = [],
+            $body2 = 'Content 2'
+        ), true);
+
+        $guzzle = new Client([
+            'handler' => HandlerStack::create($this->handler),
+        ]);
+
+        $response1 = $guzzle->request($method, 'https://goo.gl/foo');
+
+        $this->assertSame($body2, $response1->getBody()->getContents());
+        $this->assertSame($code2, $response1->getStatusCode());
+        $this->assertSame($headers2, $response1->getHeaders());
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testRegisterWithoutPassingToTopParameter()
+    {
+        $this->handler->onUriRegexpRequested('~https:\/\/goo\.gl\/.*~', $method = 'post', new Response(
+            $code1 = 200,
+            $headers1 = [],
+            $body1 = 'Content 1'
+        ));
+
+        $this->handler->onUriRegexpRequested('~https:\/\/goo\.gl\/foo.*~', $method, new Response(
+            $code2 = 202,
+            $headers2 = [],
+            $body2 = 'Content 2'
+        ));
+
+        $guzzle = new Client([
+            'handler' => HandlerStack::create($this->handler),
+        ]);
+
+        $response1 = $guzzle->request($method, 'https://goo.gl/foo');
+
+        $this->assertSame($body1, $response1->getBody()->getContents());
+        $this->assertSame($code1, $response1->getStatusCode());
+        $this->assertSame($headers1, $response1->getHeaders());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

### Added

- Parameter `$to_top` for `onUriRegexpRequested` method (it allows "override" previously declared patterns)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/tarampampam/guzzle-url-mock/blob/master/CHANGELOG.md) file

> About your changes in `CHANGELOG.md`:
>
> * Add new version header like `## v1.x.x`, if it does not exists
> * Add description under `added`/`changed`/`fixed` sections
> * Add reference to closed issues `[#000]`
> * Add link to issue in the end of document
