### PR TITLE
Fix: different reponses for same URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.2.0
+
+### Added
+
+- Can specify the number of times a response will be sent
+
 ## v1.1.0
 
 ### Added

--- a/src/UrlsMockHandler.php
+++ b/src/UrlsMockHandler.php
@@ -195,7 +195,7 @@ class UrlsMockHandler implements \Countable
             if ($to_top === true) {
                 $entry = [
                     static::RESPONSE => $response,
-                    static::TIMES =>    $times
+                    static::TIMES =>    $times,
                 ];
                 $top = [
                     $uri_pattern => [
@@ -372,7 +372,7 @@ class UrlsMockHandler implements \Countable
      */
     private function registerUri(array &$uri_array, string $uri, string $method, $response, int $times)
     {
-        $shouldRegisterUri = !isset($uri_array[$uri]);
+        $shouldRegisterUri = ! isset($uri_array[$uri]);
         if ($shouldRegisterUri) {
             $uri_array[$uri] = [
                 static::METHOD   => $method,
@@ -425,6 +425,6 @@ class UrlsMockHandler implements \Countable
             }
         }
 
-        return $response[static::RESPONSE];    
+        return $response[static::RESPONSE];
     }
 }

--- a/src/UrlsMockHandler.php
+++ b/src/UrlsMockHandler.php
@@ -195,13 +195,13 @@ class UrlsMockHandler implements \Countable
             if ($to_top === true) {
                 $entry = [
                     static::RESPONSE => $response,
-                    static::TIMES =>    $times,
+                    static::TIMES    => $times,
                 ];
                 $top = [
                     $uri_pattern => [
                         static::METHOD   => $method,
                         static::RESPONSE => [$entry],
-                    ]
+                    ],
                 ];
                 $this->uri_patterns = $top + $this->uri_patterns;
             } else {

--- a/tests/UrlsMockHandlerTest.php
+++ b/tests/UrlsMockHandlerTest.php
@@ -239,10 +239,67 @@ class UrlsMockHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(1, $this->handler->count(), 'There should be 1 response left');
 
         $response2 = $guzzle->request('get', 'https://goo.gl');
-        // $this->assertSame($body2, $response2->getBody()->getContents(), 'Third request should return second response');
+        $this->assertSame($body2, $response2->getBody()->getContents(), 'Third request should return second response');
         $this->assertSame(0, $this->handler->count(), 'There should be no responses left');
 
         // Should throw an OutOfBoundsException
         $guzzle->request('get', 'https://goo.gl');
+    }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testDifferentResponsesSameRegexUrl()
+    {
+        $this->handler->onUriRegexpRequested('~https:\/\/goo\.gl\/.*~', 'get', new Response());
+
+        $guzzle = new Client([
+            'handler' => HandlerStack::create($this->handler),
+        ]);
+
+        $response1 = $guzzle->request('get', 'https://goo.gl/foo');
+        $this->assertSame(200, $response1->getStatusCode());
+        $this->assertSame(1, $this->handler->count(), 'After one request there should still be one response left');
+
+        $response1 = $guzzle->request('get', 'https://goo.gl/foo');
+        $this->assertSame(200, $response1->getStatusCode());
+        $this->assertSame(1, $this->handler->count(), 'After two requests there should still be one response left');
+    }
+
+    /**
+     * @small
+     *
+     * @expectedException OutOfBoundsException
+     *
+     * @return void
+     */
+    public function testDifferentResponsesSameRegexUri()
+    {
+        $body1 = 'first response';
+        $this->handler->onUriRegexpRequested('~https:\/\/goo\.gl\/.*~', 'get', new Response(200, [], $body1), false, 2);
+        $body2 = 'second response';
+        $this->handler->onUriRegexpRequested('~https:\/\/goo\.gl\/.*~', 'get', new Response(200, [], $body2), false, 1);
+        $this->assertSame(3, $this->handler->count(), 'There should be three responses');
+
+        $guzzle = new Client([
+            'handler' => HandlerStack::create($this->handler),
+        ]);
+
+        $response1 = $guzzle->request('get', 'https://goo.gl/foo');
+        $this->assertSame($body1, $response1->getBody()->getContents(), 'First request should return first response');
+        $this->assertSame(2, $this->handler->count(), 'There should be 2 responses left');
+
+        $response1 = $guzzle->request('get', 'https://goo.gl/foo');
+        $this->assertSame($body1, $response1->getBody()->getContents(), 'Second request should return first response');
+        $this->assertSame(1, $this->handler->count(), 'There should be 1 response left');
+
+        $response2 = $guzzle->request('get', 'https://goo.gl/foo');
+        $this->assertSame($body2, $response2->getBody()->getContents(), 'Third request should return second response');
+        $this->assertSame(0, $this->handler->count(), 'There should be no responses left');
+
+        // Should throw an OutOfBoundsException
+        $guzzle->request('get', 'https://goo.gl/foo');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

This allows the returning of different responses from the same URI. Can also set the number of times to respond.

Fixes #4 (but I don't consider this a bug).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/tarampampam/guzzle-url-mock/blob/master/CHANGELOG.md) file
