### PR TITLE
Added support for Guzzle 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## v1.1.3
+## v1.2.0
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.1.3
+
+### Changed
+
+- Maximal `guzzlehttp/guzzle` package version now is `~7.0`
+
 ## v1.1.2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Downloads count][badge_downloads_count]][link_packagist]
 [![License][badge_license]][link_license]
 
-This package for easy mocking URLs _(fixed and regexps-based)_ using [Guzzle 6][guzzle_link].
+This package for easy mocking URLs _(fixed and regexps-based)_ using [Guzzle 6/Guzzle 7][guzzle_link].
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "tarampampam/guzzle-url-mock",
-    "description": "URLs (fixed and regexps-based) mock handler for Guzzle 6",
+    "description": "URLs (fixed and regexps-based) mock handler for Guzzle 6/Guzzle 7",
     "keywords": [
         "guzzle",
         "http",
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "guzzlehttp/guzzle": "~6.1"
+        "guzzlehttp/guzzle": "~6.1 || ~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.7.10 || ^6.4 || ~7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

### Changed

- Maximal `guzzlehttp/guzzle` package version now is `~7.0`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made changes in [CHANGELOG.md](https://github.com/tarampampam/guzzle-url-mock/blob/master/CHANGELOG.md) file

