### PR TITLE
Fix: Add buildIndex method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ## UNRELEASED
 
-### Changed
-
-- Http method names in the stack from lowercase to uppercase
-
 ### Fixed
 
-- Uppercase method names finding. Closes [#8](https://github.com/tarampampam/guzzle-url-mock/issues/8)
+- Any case method names finding [#8](https://github.com/tarampampam/guzzle-url-mock/issues/8)
 
 ## v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- Http method names in the stack from lowercase to uppercase
+
+### Fixed
+
+- Uppercase method names finding. Closes [#8](https://github.com/tarampampam/guzzle-url-mock/issues/8)
+
 ## v1.2.0
 
 ### Changed

--- a/src/UrlsMockHandler.php
+++ b/src/UrlsMockHandler.php
@@ -165,7 +165,7 @@ class UrlsMockHandler implements \Countable
     public function onUriRequested(string $uri, string $method, $response)
     {
         if ($this->validateResponse($response)) {
-            $index                   = $method . ' ' . $uri;
+            $index                   = $this->buildIndex($method, $uri);
             $this->uri_fixed[$index] = [
                 static::METHOD   => $method,
                 static::RESPONSE => $response,
@@ -197,7 +197,7 @@ class UrlsMockHandler implements \Countable
                 static::RESPONSE => $response,
             ];
 
-            $index = $method . ' ' . $uri_pattern;
+            $index = $this->buildIndex($method, $uri_pattern);
             if ($to_top === true) {
                 $this->uri_patterns = [$index => $entry] + $this->uri_patterns;
             } else {
@@ -272,7 +272,7 @@ class UrlsMockHandler implements \Countable
         $uri    = $request->getUri()->__toString();
         $method = \mb_strtoupper($request->getMethod());
 
-        $index = $method . ' ' . $uri;
+        $index = $this->buildIndex($method, $uri);
         if (isset($this->uri_fixed[$index])) {
             return $this->uri_fixed[$index][static::RESPONSE];
         }
@@ -328,6 +328,19 @@ class UrlsMockHandler implements \Countable
         if (isset($options['on_stats']) && \is_callable($on_stats = $options['on_stats'])) {
             $on_stats(new TransferStats($request, $response, null, $reason));
         }
+    }
+
+    /**
+     * Build index for registered requests.
+     *
+     * @param string $method
+     * @param string $uri
+     *
+     * @return string
+     */
+    protected function buildIndex(string $method, string $uri): string
+    {
+        return mb_strtoupper($method) . ' ' . $uri;
     }
 
     /**

--- a/src/UrlsMockHandler.php
+++ b/src/UrlsMockHandler.php
@@ -270,7 +270,7 @@ class UrlsMockHandler implements \Countable
     protected function findResponseForRequest(RequestInterface $request)
     {
         $uri    = $request->getUri()->__toString();
-        $method = \mb_strtolower($request->getMethod());
+        $method = \mb_strtoupper($request->getMethod());
 
         $index = $method . ' ' . $uri;
         if (isset($this->uri_fixed[$index])) {
@@ -279,7 +279,7 @@ class UrlsMockHandler implements \Countable
 
         foreach ($this->uri_patterns as $uri_pattern => $rule_array) {
             $uri_pattern = $this->removeMethodFromPattern($uri_pattern);
-            if (\preg_match($uri_pattern, $uri) && \mb_strtolower($rule_array[static::METHOD]) === $method) {
+            if (\preg_match($uri_pattern, $uri) && \mb_strtoupper($rule_array[static::METHOD]) === $method) {
                 return $rule_array[static::RESPONSE];
             }
         }

--- a/tests/UrlsMockHandlerTest.php
+++ b/tests/UrlsMockHandlerTest.php
@@ -231,4 +231,31 @@ class UrlsMockHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($code1, $response1->getStatusCode());
         $this->assertEquals($code2, $response2->getStatusCode());
     }
+
+    /**
+     * @small
+     *
+     * @return void
+     */
+    public function testCaseInsensitiveHttpMethod()
+    {
+        $this->handler->onUriRequested('https://goo.gl/1', 'GET', new Response(200));
+        $this->handler->onUriRequested('https://goo.gl/2', 'get', new Response(200));
+        $this->handler->onUriRequested('https://goo.gl/3', 'gEt', new Response(200));
+        $this->handler->onUriRequested('https://goo.gl/4', 'Post', new Response(200));
+
+        $guzzle = new Client([
+            'handler' => HandlerStack::create($this->handler),
+        ]);
+
+        $response1 = $guzzle->request('get', 'https://goo.gl/1');
+        $response2 = $guzzle->request('GET', 'https://goo.gl/2');
+        $response3 = $guzzle->request('GeT', 'https://goo.gl/3');
+        $response4 = $guzzle->request('POST', 'https://goo.gl/4');
+
+        $this->assertEquals(200, $response1->getStatusCode());
+        $this->assertEquals(200, $response2->getStatusCode());
+        $this->assertEquals(200, $response3->getStatusCode());
+        $this->assertEquals(200, $response4->getStatusCode());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

Then you try to register request with uppercase (e.g `GET`) handler can't find it. We've got:

`OutOfBoundsException: There is no action for requested URI: https://goo.gl (GET)`


Fixes #8 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in [CHANGELOG.md](https://github.com/tarampampam/guzzle-url-mock/blob/master/CHANGELOG.md) file